### PR TITLE
new direction mode required in some case

### DIFF
--- a/opengalax.c
+++ b/opengalax.c
@@ -275,6 +275,11 @@ int main (int argc, char *argv[]) {
 				x = Y_AXIS_MAX - ((int)ya * YB_MAX) + (YB_MAX - (int)yb);
 				y = ((int)xa * XB_MAX) + ((int)xb);
 				break;
+			case 5:
+				x = ((int)ya * YB_MAX) + ((int)yb);
+				y = ((int)xa * XB_MAX) + ((int)xb);
+				break;
+
 		}
 
 		if (calibration_mode) {


### PR DESCRIPTION
The driver was working but I experiemented strange behavior:
With direction mode 0, X and Y axis were inverted and X was reversed but not Y.
None of the direction modes (I tested mode 3 too) was working correctly so I simply decided to add a new mode.

I'm using the touchscreen on Debian Testing (3.2.0-3-486 kernel) on a panel PC.
